### PR TITLE
Fixed Waist Size not loading when editing it directly

### DIFF
--- a/utils/functions.lua
+++ b/utils/functions.lua
@@ -572,10 +572,13 @@ end
 
 function LoadBodySize(target, data)
     Citizen.InvokeNative(0x1902C4CFCC5BE57C, target, BODY_TYPES[tonumber(data.body_size)])
+    NativeUpdatePedVariation(target)
+    
 end
 
 function LoadBodyWaist(target, data)
     Citizen.InvokeNative(0x1902C4CFCC5BE57C, target, WAIST_TYPES[tonumber(data.body_waist)])
+    NativeUpdatePedVariation(target)
 end
 
 function LoadFeatures(target, data)


### PR DESCRIPTION
It was missing native to update metaped outfit, that's why changing the waist size was only visible when altering the body type, now both of them works individually perfectly.